### PR TITLE
ci: 增加发布action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches: [master]
   push:
+    tags:
+      - v**
     branches:
       - master
 
@@ -39,3 +41,33 @@ jobs:
         with:
           name: scow-slurm-adapter
           path: ./scow-slurm-adapter
+
+  release:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+
+    if: github.ref_type == 'tag'
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download scow-slurm-adapter
+        uses: actions/download-artifact@v3
+        with:
+          name: scow-slurm-adapter
+          path: release
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: release
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          files: |
+            release/scow-slurm-adapter


### PR DESCRIPTION
增加一个GitHub Action。当往仓库push一个以`v`开头的tag时，GitHub Action将会自动构建项目，并自动创建一个以tag名为标题的release，其中的asset包含构建好的二进制。tag的格式应该为`v{版本号}`，例如`v0.1.0`