### PR TITLE
ci: 增加ARM64构建

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,23 +24,27 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: stable
-        
+
       - name: PB Codegen
         run: make protos
-        
+
       - name: Test
         # When unit test is ready, change this to true
         if: false
         run: make test
 
-      - name: Build binary
-        run: CGO_BUILD=0 make build
+      - name: Build binaries
+        run: |
+          make ARCH=amd64 build
+          make ARCH=arm64 build
 
       - name: Upload binary
         uses: actions/upload-artifact@v3
         with:
           name: scow-slurm-adapter
-          path: ./scow-slurm-adapter
+          path: |
+            ./scow-slurm-adapter-amd64
+            ./scow-slurm-adapter-arm64
 
   release:
     runs-on: ubuntu-latest
@@ -70,4 +74,5 @@ jobs:
         with:
           generate_release_notes: true
           files: |
-            release/scow-slurm-adapter
+            release/scow-slurm-adapter-amd64
+            release/scow-slurm-adapter-arm64

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+ARCH ?= amd64
+
 protos: 
 	buf generate --template buf.gen.yaml https://github.com/PKUHPC/scow-scheduler-adapter-interface.git#subdir=protos
 
@@ -5,7 +7,7 @@ run:
 	go run *.go 
 
 build:
-	go build
+	CGO_BUILD=0 GOARCH=${ARCH} go build -o scow-slurm-adapter-${ARCH}
 
 test:
 	go test


### PR DESCRIPTION
- Makefile里增加`ARCH`变量，默认为`amd64`，生成的文件改为`scow-slurm-adapter-$ARCH`。
- 每次CI同时构建`amd64`和`arm64`两种版本的二进制