### PR TITLE
显式指定需要实现的调度器适配器接口版本

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ARCH ?= amd64
 
 protos: 
-	buf generate --template buf.gen.yaml https://github.com/PKUHPC/scow-scheduler-adapter-interface.git#subdir=protos
+	buf generate --template buf.gen.yaml https://github.com/PKUHPC/scow-scheduler-adapter-interface.git#subdir=protos,tag=v1.0.1
 
 run: 
 	go run *.go 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # slurm adapter for SCOW
 
+当前实现的`scow-scheduluer-adapter-interface`版本：v1.0.1
+
 ## Build
 
 Requires [Buf]([Buf](https://buf.build/docs/installation/)).


### PR DESCRIPTION
在Makefile中指定需要实现的调度器适配器接口版本，并在README中提及。