### PR TITLE
1. 日志支持打印具体文件行数；2. GetClusterNodesInfo当查询所有节点时，可以通过一行命令解析，解析代码属于CPU密集…

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 
 	"scow-slurm-adapter/caller"
 	pb "scow-slurm-adapter/gen/go"
-
 	"scow-slurm-adapter/services/account"
 	"scow-slurm-adapter/services/app"
 	"scow-slurm-adapter/services/config"


### PR DESCRIPTION
1. 日志支持打印具体文件行数；
2. GetClusterNodesInfo当查询所有节点时，可以通过一行命令解析，解析代码属于CPU密集型运算，没必要开协程一个一个查询当个节点，节点数量太多时反而效率会低。